### PR TITLE
Output sequence names in predictable order

### DIFF
--- a/lib/ar/sequence/adapter.rb
+++ b/lib/ar/sequence/adapter.rb
@@ -4,7 +4,7 @@ module AR
   module Sequence
     module Adapter
       def check_sequences
-        select_all("SELECT * FROM information_schema.sequences").to_a
+        select_all("SELECT * FROM information_schema.sequences ORDER BY sequence_name").to_a
       end
 
       def create_sequence(name, options = {})

--- a/test/ar/sequence_test.rb
+++ b/test/ar/sequence_test.rb
@@ -108,6 +108,19 @@ class SequenceTest < Minitest::Test
     assert_nil ActiveRecord::Base.connection.check_sequences.find {|seq| seq["sequence_name"] == "position" }
   end
 
+  test "orders sequences" do
+    with_migration do
+      def up
+        create_sequence :c
+        create_sequence :a
+        create_sequence :b
+      end
+    end.up
+
+    list = ActiveRecord::Base.connection.check_sequences
+    assert_equal list.map {|s| s["sequence_name"] }, %w[a b c things_id_seq]
+  end
+
   test "dumps schema" do
     with_migration do
       def up


### PR DESCRIPTION
Currently, the order of sequence names is not predictable so we see the order in schema.rb fluctuating between different developers, which is not nice :)

A quick merge/release would be really appreciated.

Cheers,
Dim