### PR TITLE
Dump sequence information after table information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Prefix your message with one of the following:
 - [Security] in case of vulnerabilities.
 -->
 
+## Unreleased
+
+- [Changed] Sequence information is now written after table information in the schema dump.
+
 ## v0.1.2 - 2020-09-23
 
 - [Changed] Output sequence names in predictable order.

--- a/lib/ar/sequence/schema_dumper.rb
+++ b/lib/ar/sequence/schema_dumper.rb
@@ -3,9 +3,9 @@
 module AR
   module Sequence
     module SchemaDumper
-      def header(stream)
-        super
+      def trailer(stream)
         sequences(stream)
+        super
       end
 
       def sequences(stream)


### PR DESCRIPTION
### What
When dumping the schema, put the `create_sequence` entries after the `create_table` entries.

### Why
Since the schema dump includes sequences which are automatically generated for table ids, loading from the schema will create these if they do not exist. Having them appear before the tables are created means the create table statements will make new sequences with `1` appended to the name to avoid a clash.

For example:
```
ActiveRecord::Schema.define(version: 0) do
  
  create_sequence "things_id_seq"
  # creates things_id_seq

  create_table "things", force: :cascade do |t|
    t.integer "quantity", default: 0
    t.string "slug"
  end
  # tries to create things_id_seq, runs into a clash and creates things_id_seq1 instead

end
```

This won't happen the other way around though, because `create_sequence` checks for existence first.

### Known limitations
A little bit hard to test, any suggestions for making it more concise?
