### PR TITLE
Do not dump auto-generated sequences to schema.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Prefix your message with one of the following:
 - [Security] in case of vulnerabilities.
 -->
 
+## Unreleased
+
+- [Changed] Only dump sequences created by ar_sequence (using Postgres COMMENT)
+
 ## v0.1.2 - 2020-09-23
 
 - [Changed] Output sequence names in predictable order.

--- a/lib/ar/sequence/adapter.rb
+++ b/lib/ar/sequence/adapter.rb
@@ -3,6 +3,14 @@
 module AR
   module Sequence
     module Adapter
+      SEQUENCE_COMMENT = "created by ar-sequence"
+
+      def custom_sequence?(sequence_name)
+        execute(
+          "SELECT obj_description('#{sequence_name}'::regclass, 'pg_class');"
+        ).first["obj_description"] == SEQUENCE_COMMENT
+      end
+
       def check_sequences
         select_all(
           "SELECT * FROM information_schema.sequences ORDER BY sequence_name"
@@ -16,6 +24,8 @@ module AR
         sql = ["CREATE SEQUENCE IF NOT EXISTS #{name}"]
         sql << "INCREMENT BY #{increment}" if increment
         sql << "START WITH #{options[:start]}" if options[:start]
+        sql << ";"
+        sql << "COMMENT ON SEQUENCE #{name} IS '#{SEQUENCE_COMMENT}';"
 
         execute(sql.join("\n"))
       end

--- a/lib/ar/sequence/schema_dumper.rb
+++ b/lib/ar/sequence/schema_dumper.rb
@@ -13,6 +13,8 @@ module AR
         return if sequences.empty?
 
         sequences.each do |seq|
+          next unless @connection.custom_sequence?(seq["sequence_name"])
+
           start_value = seq["start_value"]
           increment = seq["increment"]
 

--- a/test/ar/sequence_test.rb
+++ b/test/ar/sequence_test.rb
@@ -145,6 +145,23 @@ class SequenceTest < Minitest::Test
     assert_match(/create_sequence "d", start: 100, increment: 2$/, contents)
   end
 
+  test "does not dump auto-generated sequences to schema" do
+    with_migration do
+      def up
+        drop_table :things
+        create_table :things, id: :serial do |t|
+          t.text :name
+        end
+      end
+    end.up
+
+    stream = StringIO.new
+    ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection, stream)
+    contents = stream.tap(&:rewind).read
+
+    refute_match(/create_sequence/, contents)
+  end
+
   test "creates table that references sequence" do
     with_migration do
       def up


### PR DESCRIPTION
### What

When dumping the schema, only add the sequences that were created using "create_sequence". Ignore all auto-generated sequences to prevent issues.  

### Why

Sequences need to be defined before creating tables otherwise they cannot be used/referenced (see example below).

```
create_sequence "some_sequence", start: 100

create_table "things", force: :cascade do |t|
    ...
    t.bigint "sequence_number", default: -> { "nextval('some_sequence'::regclass)" }
	...
```

However: if also the auto-generated sequences are added to schema.rb, this results in additional sequences to be created as mentioned in https://github.com/fnando/ar-sequence/pull/4

Not all sequences are dumped anymore now, is that a problem? In my opinion (please shoot if I am missing anything):
-  I find it cleaner to only have the manually created sequences in schema.rb. 
-  If you created a sequence manually before, you probably have other code in place now (as the sequence has to be re-created if you dump and recreate your database). When migrating to ar-sequence you can cleanup that code and manually add a line in schema.rb once to make it work.

### Known limitations

I was unable to run the tests locally...
