### PR TITLE
Dump schema names that aren't on the default search path.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Prefix your message with one of the following:
 
 ## Unreleased
 
-- [Changed] Add sequences in custom schemas support.
+- [Changed] Dump schema names that aren't on the default search path.
 
 ## v0.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Prefix your message with one of the following:
 - [Security] in case of vulnerabilities.
 -->
 
+## Unreleased
+
+- [Changed] Add sequences in custom schemas support.
+
 ## v0.2.0
 
 - [Changed] Only dump sequences created by ar_sequence (using Postgres COMMENT).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Prefix your message with one of the following:
 
 - [Changed] Dump schema names that aren't on the default search path.
 
-## v0.2.0
+## v0.2.0 - 2021-09-16
 
 - [Changed] Only dump sequences created by ar_sequence (using Postgres COMMENT).
 

--- a/lib/ar/sequence/adapter.rb
+++ b/lib/ar/sequence/adapter.rb
@@ -41,7 +41,7 @@ module AR
       end
 
       def quote_name(name)
-        name.split(".", 2).map { |part| quote_column_name(part) }.join(".")
+        name.split(".", 2).map {|part| quote_column_name(part) }.join(".")
       end
     end
   end

--- a/lib/ar/sequence/adapter.rb
+++ b/lib/ar/sequence/adapter.rb
@@ -19,7 +19,7 @@ module AR
 
       def create_sequence(name, options = {})
         increment = options[:increment] || options[:step]
-        name = quote_column_name(name)
+        name = quote_name(name)
 
         sql = ["CREATE SEQUENCE IF NOT EXISTS #{name}"]
         sql << "INCREMENT BY #{increment}" if increment
@@ -35,9 +35,13 @@ module AR
       #   drop_sequence :user_position
       #
       def drop_sequence(name)
-        name = quote_column_name(name)
+        name = quote_name(name)
         sql = "DROP SEQUENCE #{name}"
         execute(sql)
+      end
+
+      def quote_name(name)
+        name.split(".", 2).map { |part| quote_column_name(part) }.join(".")
       end
     end
   end

--- a/lib/ar/sequence/schema_dumper.rb
+++ b/lib/ar/sequence/schema_dumper.rb
@@ -13,7 +13,8 @@ module AR
         return if sequences.empty?
 
         sequences.each do |seq|
-          next unless @connection.custom_sequence?(seq["sequence_name"])
+          sequence_full_name = [seq["sequence_schema"], seq["sequence_name"]].join(".")
+          next unless @connection.custom_sequence?(sequence_full_name)
 
           start_value = seq["start_value"]
           increment = seq["increment"]
@@ -30,7 +31,7 @@ module AR
 
           statement = [
             "create_sequence",
-            seq["sequence_name"].inspect
+            sequence_full_name.inspect
           ].join(" ")
 
           if options.any?

--- a/test/ar/sequence_test.rb
+++ b/test/ar/sequence_test.rb
@@ -133,6 +133,7 @@ class SequenceTest < Minitest::Test
         create_sequence :b, start: 100
         create_sequence :c, increment: 2
         create_sequence :d, start: 100, step: 2
+        create_sequence "my_schema.e"
       end
     end.up
 
@@ -144,6 +145,7 @@ class SequenceTest < Minitest::Test
     assert_match(/create_sequence "b", start: 100$/, contents)
     assert_match(/create_sequence "c", increment: 2$/, contents)
     assert_match(/create_sequence "d", start: 100, increment: 2$/, contents)
+    assert_match(/create_sequence "my_schema.e"$/, contents)
   end
 
   test "does not dump auto-generated sequences to schema" do

--- a/test/support/active_record.rb
+++ b/test/support/active_record.rb
@@ -61,6 +61,7 @@ def recreate_table
     execute "drop sequence if exists b"
     execute "drop sequence if exists c"
     execute "drop sequence if exists d"
+    execute "drop sequence if exists my_schema.e"
 
     create_table :things do |t|
       t.integer :quantity, default: 0

--- a/test/support/helpers.rb
+++ b/test/support/helpers.rb
@@ -13,6 +13,7 @@ module TestHelper
       execute "drop sequence if exists b"
       execute "drop sequence if exists c"
       execute "drop sequence if exists d"
+      execute "drop sequence if exists my_schema.e"
 
       create_table :things do |t|
         t.integer :quantity, default: 0

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -20,17 +20,14 @@ end
 module TestHelper
   def recreate_table
     ActiveRecord::Schema.define(version: 0) do
-      begin
-        drop_table(:things)
-      rescue StandardError
-        nil
-      end
+      drop_table :things, if_exists: true
       execute "drop sequence if exists position"
       execute "drop sequence if exists a"
       execute "drop sequence if exists b"
       execute "drop sequence if exists c"
       execute "drop sequence if exists d"
       execute "drop sequence if exists my_schema.e"
+      execute "create schema if not exists my_schema"
 
       create_table :things do |t|
         t.integer :quantity, default: 0

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -30,6 +30,7 @@ module TestHelper
       execute "drop sequence if exists b"
       execute "drop sequence if exists c"
       execute "drop sequence if exists d"
+      execute "drop sequence if exists my_schema.e"
 
       create_table :things do |t|
         t.integer :quantity, default: 0


### PR DESCRIPTION
<!--
If you're making a doc PR or something tiny where the below is irrelevant,
delete this template and use a short description, but in your description aim to
include both what the change is, and why it is being made, with enough context
for anyone to understand.
-->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [x] This PR has reasonably narrow scope (if not, break it down into smaller
      PRs).
- [x] This PR avoids mixing refactoring changes with feature changes (split into
      two PRs otherwise).
- [x] This PR's title starts is concise and descriptive.

### Thoroughness

- [x] This PR adds tests for the most critical parts of the new functionality or
      fixes.
- [x] I've updated any docs, `.md` files, etc… affected by this change.

</details>

### What

Dump custom schemas when they're not in the search path.

### Why

Otherwise we'd create sequences using the wrong schema.

### Known limitations

N/A
