### PR TITLE
Add support for multi db setups with a different adapter

### DIFF
--- a/ar-sequence.gemspec
+++ b/ar-sequence.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) {|f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord"
+  spec.add_dependency "activerecord", ">= 5"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "minitest-utils"

--- a/lib/ar/sequence.rb
+++ b/lib/ar/sequence.rb
@@ -21,5 +21,5 @@ ActiveRecord::Migration::CommandRecorder.include(AR::Sequence::CommandRecorder)
 ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.include(
   AR::Sequence::Adapter
 )
-ActiveRecord::SchemaDumper.prepend(AR::Sequence::SchemaDumper)
+ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaDumper.prepend(AR::Sequence::SchemaDumper)
 ActiveRecord::Base.extend(AR::Sequence::ModelMethods)

--- a/lib/ar/sequence/schema_dumper.rb
+++ b/lib/ar/sequence/schema_dumper.rb
@@ -3,9 +3,9 @@
 module AR
   module Sequence
     module SchemaDumper
-      def header(stream)
-        super
+      def extensions(stream)
         sequences(stream)
+        super
       end
 
       def retrieve_search_path


### PR DESCRIPTION
### What

1. I've modified the code to hook into the `ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaDumper` instead of the generic `ActiveRecord::SchemaDumper` and added the sequences' logic to the `extensions` section (which to me seems like a good place to put this).
2. The `ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaDumper` exist since ActiveRecord 5, so I've also included this in the gemspec

### Why

I was implementing solid_cable using SQLite as an adapter and came across this issue, where the schema dumper was trying to dump the sequences for the SQLite solid cable schema. Obviously, this isn't possible.

